### PR TITLE
fixed reference variable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,4 @@ build:
 		.
 
 start:
-	docker run -d --name $(NAME) opensips/opensips:$(OPENSIPS_VERSION)
+	docker run -d --name $(NAME) opensips/opensips:$(OPENSIPS_DOCKER_TAG)


### PR DESCRIPTION
Issue - 
While compiling the docker image, we were adding **latest** as an image tag. But after compilation when we run the docker container using that image, we were passing the wrong variable in Makefile.

Outcome - 
While starting the container using make start, we passed the wrong image tag and the docker was unable to locate the newly created image, therefore, it starts pulling old docker image from the docker hub. 

Solution - 
Pass the correct tag variable in Makefile 
`docker run -d --name $(NAME) opensips/opensips:**$(OPENSIPS_DOCKER_TAG)**`

Please review it @razvancrainea 

Thank you