### PR TITLE
Fix GHA deprecation warning about actions still running on Node.js 20

### DIFF
--- a/.github/actions/docker-opensips-publish/action.yml
+++ b/.github/actions/docker-opensips-publish/action.yml
@@ -15,16 +15,16 @@ inputs:
     description: Indicates whether to install OpenSIPS CLI as well
     required: false
   modules:
-    description: Space separated additional packets to install
+    description: Space-separated additional packages to install
     required: false
   build:
-    description: Indicate the build to use
+    description: Indicates the build to use
     required: false
   docker-username:
-    description: The Docker username to push the image with
+    description: The Docker username to push the image as
     required: true
   docker-token:
-    description: The Docker token used to authenticate
+    description: The Docker authentication token used
     required: true
 
 runs:

--- a/.github/actions/docker-opensips-publish/action.yml
+++ b/.github/actions/docker-opensips-publish/action.yml
@@ -31,7 +31,7 @@ runs:
   using: "composite"
 
   steps:
-  - uses: actions/checkout@v4
+  - uses: actions/checkout@v6
     with:
       repository: OpenSIPS/docker-opensips
 
@@ -51,7 +51,7 @@ runs:
     run: make build 2>&1 | tee /tmp/build.log && grep "naming to docker.io" /tmp/build.log | awk  -F'[ /]' '{print "DOCKER_TAG=" $5 "/" $6 }' >> $GITHUB_OUTPUT
 
   - name: Log in to Docker Hub
-    uses: docker/login-action@v3
+    uses: docker/login-action@v4
     with:
       username: ${{ inputs.docker-username }}
       password: ${{ inputs.docker-token }}

--- a/.github/workflows/docker-readme.yml
+++ b/.github/workflows/docker-readme.yml
@@ -12,7 +12,7 @@ jobs:
   dockerHubDescription:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
 
     - name: Docker Hub Description


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/