### PR TITLE
Add GHCR publishing support and update actions

### DIFF
--- a/.github/actions/docker-opensips-publish/action.yml
+++ b/.github/actions/docker-opensips-publish/action.yml
@@ -1,6 +1,6 @@
 ---
-name: Publish OpenSIPS Image in Docker Hub
-description: Builds and publishes OpenSIPS docker image to Docker Hub
+name: Publish OpenSIPS Image
+description: Builds and publishes OpenSIPS docker image to Docker Hub and optionally to GitHub Container Registry
 inputs:
   version:
     description: OpenSIPS Version to build the image for
@@ -26,6 +26,9 @@ inputs:
   docker-token:
     description: The Docker authentication token used
     required: true
+  ghcr-token:
+    description: GitHub token used to push to ghcr.io (omit to skip GHCR publishing)
+    required: false
 
 runs:
   using: "composite"
@@ -56,6 +59,22 @@ runs:
       username: ${{ inputs.docker-username }}
       password: ${{ inputs.docker-token }}
 
-  - name: Publish the Docker image
+  - name: Log in to GitHub Container Registry
+    if: ${{ inputs.ghcr-token != '' }}
+    uses: docker/login-action@v4
+    with:
+      registry: ghcr.io
+      username: ${{ github.repository_owner }}
+      password: ${{ inputs.ghcr-token }}
+
+  - name: Publish the Docker image to Docker Hub
     shell: bash
     run: docker push ${{ steps.build.outputs.DOCKER_TAG }}
+
+  - name: Publish the Docker image to GitHub Container Registry
+    if: ${{ inputs.ghcr-token != '' }}
+    shell: bash
+    run: |
+      GHCR_TAG="ghcr.io/${{ github.repository_owner }}/opensips:${OPENSIPS_DOCKER_TAG:-latest}"
+      docker tag "opensips/opensips:${OPENSIPS_DOCKER_TAG:-latest}" "$GHCR_TAG"
+      docker push "$GHCR_TAG"

--- a/.github/workflows/docker-opensips-publish.yml
+++ b/.github/workflows/docker-opensips-publish.yml
@@ -1,4 +1,4 @@
-name: Publish OpenSIPS Image in Docker Hub
+name: Publish OpenSIPS Image
 
 on:
   workflow_dispatch:
@@ -31,6 +31,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      packages: write
+
     steps:
     - name: Publish OpenSIPS Docker image
       uses: OpenSIPS/docker-opensips/.github/actions/docker-opensips-publish@main
@@ -43,3 +46,4 @@ jobs:
         component: ${{ github.event.inputs.component }}
         docker-username: ${{ secrets.DOCKER_USERNAME }}
         docker-token: ${{ secrets.DOCKER_TOKEN }}
+        ghcr-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-readme.yml
+++ b/.github/workflows/docker-readme.yml
@@ -16,7 +16,7 @@ jobs:
 
 
     - name: Docker Hub Description
-      uses: peter-evans/dockerhub-description@v4
+      uses: peter-evans/dockerhub-description@v5
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_TOKEN }}


### PR DESCRIPTION
- Publish images to ghcr.io in addition to Docker Hub, using github.repository_owner for the GHCR login and image namespace
- Add packages: write permission to the publish workflow
- Bump peter-evans/dockerhub-description from v4 to v5 (Node 24 runtime)