### PR TITLE
Use opensips-mi instead of opensips-cli for healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,4 +58,4 @@ HEALTHCHECK --interval=15s --timeout=5s \
     CMD if [ "$OPENSIPS_CLI_ENV" != "true" ]; then \
             exit 0; \
         fi; \
-        opensips-cli -x mi uptime | grep -q "Up Time" || exit 1
+        opensips-mi uptime 2>/dev/null | grep -q "Up since" || exit 1


### PR DESCRIPTION
- uptime will fail on >= 4.0 with opensips-cli since it checks the command against `which` output, that contains only namespaced 'core:uptime'
- fix grep: 'Up Time' is not present in the output of uptime